### PR TITLE
ci(benstalk): add iam role

### DIFF
--- a/.vtex/deployment.json
+++ b/.vtex/deployment.json
@@ -11,9 +11,10 @@
         "AWS_REGION": "us-east-1",
         "SLACK_CHANNEL": "checkout-ui-notifications",
         "CUSTOM_PIPELINE": true,
-        "PIPELINE_CI":".vtex/Jenkins_CI",
-        "PIPELINE_Deploy":".vtex/Jenkins_Deploy"
+        "PIPELINE_CI": ".vtex/Jenkins_CI",
+        "PIPELINE_Deploy": ".vtex/Jenkins_Deploy"
       }
-    }
+    },
+    "iamInstanceProfile": "BeanstalkRole_front.libs"
   }
 ]


### PR DESCRIPTION

# Setting application's IAM Role

Hello, how are you? I am creating this pull request to change your application, so each service defined in `.vtex/deployment.json` has their own IAM role.
This is the initial step for creating a role for our beanstalk applications, here at VTEX. The next step is to edit each role, so that each service has the least privilege that it needs to run.

## What is an IAM Role?

An IAM role defines what privileges an app has when interacting with cloud resources (such as S3 objects, SQS queues, SNS objects and so on).
Today, every app receives a general role, which has far more privileges than it needs.

## Where is my role defined?

Each service has it own roles:
- [front-libs](https://github.com/vtex/application-roles/blob/main/roles/beanstalk-roles/front.libs/front-libs/role.yaml)

We have documented the process for creating/editing this file [here](https://internal-docs.vtex.com/Security%20%26%20Privacy/Documents/creating-roles/).

## I have more questions

You can contact us at `#trusthub` in Slack.
